### PR TITLE
Introduce Subprocess

### DIFF
--- a/Sources/FoundationEssentials/Subprocess+Linux.swift
+++ b/Sources/FoundationEssentials/Subprocess+Linux.swift
@@ -1,0 +1,54 @@
+//
+//  File.swift
+//
+//
+//  Created by Charles Hu
+//
+
+import System
+internal import _CShims
+
+#if os(Linux)
+import Glibc
+
+extension Subprocess {
+    public func run() throws -> ProcessIdentifier {
+        // Sanity check: executablePath can't be empty
+        guard !executablePath.isEmpty else {
+            throw SubprocessError.invalidExecutablePath
+        }
+        if self.blacklist.contains(executablePath) {
+            throw SubprocessError.processNotSupported
+        }
+        // Prepare the environment
+        // Inheirt the environent value from the master process
+        var environmentValues = ProcessInfo.processInfo.environment
+        for (key, value) in self.environments {
+            environmentValues[key] = value
+        }
+        let env = environmentValues.map { (key, value) in
+            return strdup("\(key)=\(value)")
+        }
+        // Prepare the environment
+        var args: [UnsafeMutablePointer<CChar>?] = [
+            strdup(self.executablePath)
+        ]
+        for arg in self.arguments {
+            args.append(strdup(arg))
+        }
+        let fileDescriptors: [CInt] = [
+            self.standardInput?.rawValue ?? 0,
+            self.standardInput?.rawValue ?? 0,
+            self.standardError?.rawValue ?? 0
+        ]
+        var pid: ProcessIdentifier = 0
+        self.executablePath.withCString { exePath in
+            fileDescriptors.withUnsafeBufferPointer { fds in
+                _subprocess_fork_exec(&pid, exePath, fds, args, env)
+            }
+        }
+        return pid
+    }
+}
+
+#endif

--- a/Sources/FoundationEssentials/Subprocess.swift
+++ b/Sources/FoundationEssentials/Subprocess.swift
@@ -1,0 +1,128 @@
+//
+//  Subprocess.swift
+//
+//
+//  Created by Charles Hu
+//
+
+import System
+import Darwin
+internal import _CShims
+
+public typealias ProcessIdentifier = pid_t
+
+public struct Subprocess {
+    public let executablePath: String
+    public let arguments: [String]
+    public let environments: [String : String]
+
+    public let standardInput: FileDescriptor?
+    public let standardOutput: FileDescriptor?
+    public let standardError: FileDescriptor?
+    // We don't support launching these processes
+    internal let blacklist: Set<String> = ["/usr/bin/swift", "/bin/sh", "/bin/zsh"]
+
+    public init(
+        executablePath: String,
+        arguments: [String],
+        environments: [String : String],
+        standardInput: FileDescriptor? = nil,
+        standardOutput: FileDescriptor? = nil,
+        standardError: FileDescriptor? = nil) {
+        self.executablePath = executablePath
+        self.arguments = arguments
+        self.environments = environments
+        self.standardInput = standardInput
+        self.standardOutput = standardOutput
+        self.standardError = standardError
+    }
+
+#if os(macOS)
+    public func run() throws -> ProcessIdentifier {
+        // Sanity check: executablePath can't be empty
+        guard !executablePath.isEmpty else {
+            throw SubprocessError.invalidExecutablePath
+        }
+        if self.blacklist.contains(executablePath) {
+            throw SubprocessError.processNotSupported
+        }
+        // Prepare the environment
+        // Inheirt the environent value from the master process
+        var environmentValues = ProcessInfo.processInfo.environment
+        for (key, value) in self.environments {
+            environmentValues[key] = value
+        }
+        let env = environmentValues.map { (key, value) in
+            return strdup("\(key)=\(value)")
+        }
+        // Prepare the environment
+        var args: [UnsafeMutablePointer<CChar>?] = [
+            strdup(self.executablePath)
+        ]
+        for arg in self.arguments {
+            args.append(strdup(arg))
+        }
+        // Setup file actions
+        var fileActions: posix_spawn_file_actions_t? = nil
+        // Create file actions
+        posix_spawn_file_actions_init(&fileActions)
+        defer {
+            // Destroy file actions
+            posix_spawn_file_actions_destroy(&fileActions)
+        }
+        // Setup standard input
+        if let inputFd = self.standardInput {
+            posix_spawn_file_actions_adddup2(&fileActions, inputFd.rawValue, 0)
+        }
+        // Setup standard output
+        if let outputFd = self.standardOutput {
+            posix_spawn_file_actions_adddup2(&fileActions, outputFd.rawValue, 1)
+        }
+        // Setup standard error
+        if let errorFd = self.standardError {
+            posix_spawn_file_actions_adddup2(&fileActions, errorFd.rawValue, 2)
+        }
+        // Setup spawn attributes
+        var spawnAttributes: posix_spawnattr_t? = nil
+        defer {
+            posix_spawnattr_destroy(&spawnAttributes)
+        }
+        var noSignals = sigset_t()
+        var allSignals = sigset_t()
+        sigemptyset(&noSignals)
+        sigfillset(&allSignals)
+        posix_spawnattr_setsigmask(&spawnAttributes, &noSignals)
+        posix_spawnattr_setsigdefault(&spawnAttributes, &allSignals)
+        let flags: Int32 = POSIX_SPAWN_CLOEXEC_DEFAULT |
+            POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF
+        posix_spawnattr_setflags(&spawnAttributes, Int16(flags))
+        // Spawn
+        var pid: pid_t = 0
+        executablePath.withCString { exePath in
+            _subprocess_spawn(
+                &pid, exePath,
+                &fileActions, &spawnAttributes,
+                args, env)
+        }
+
+        return pid
+    }
+#endif
+}
+
+public enum SubprocessError: Error {
+    case invalidExecutablePath
+    case processNotSupported
+}
+
+//extension Subprocess {
+//    public func resolvedEnvironmentValues() -> [String : String] {
+//        // Prepare the environment
+//        // Inheirt the environent value from the master process
+//        var environmentValues = ProcessInfo.processInfo.environment
+//        for (key, value) in self.environments {
+//            environmentValues[key] = value
+//        }
+//        return environmentValues
+//    }
+//}

--- a/Sources/_CShims/ProcessShims.c
+++ b/Sources/_CShims/ProcessShims.c
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#include "include/_CShimsTargetConditionals.h"
+#include "include/ProcessShims.h"
+#include <errno.h>
+#include <signal.h>
+
+#if TARGET_OS_MAC
+
+int _subprocess_spawn(
+    pid_t *pid,
+    const char *exec_path,
+    const posix_spawn_file_actions_t *file_actions,
+    const posix_spawnattr_t *spawn_attrs,
+    char * const args[],
+    char * const env[]
+) {
+    return posix_spawn(pid, exec_path, file_actions, spawn_attrs, args, env);
+}
+
+#else
+
+#if _POSIX_SPAWN
+static int _subprocess_posix_spawn_fallback(
+    pid_t * pid,
+    const char * exec_path,
+    const int file_descriptors[],
+    char * const args[],
+    char * const env[]
+) {
+    // Setup stdin, stdout, and stderr
+    posix_spawn_file_actions_t file_actions;
+    posix_spawn_file_actions_init(&file_actions);
+    posix_spawn_file_actions_adddup2(&file_actions, file_descriptors[0], STDIN_FILENO);
+    posix_spawn_file_actions_adddup2(&file_actions, file_descriptors[1], STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&file_actions, file_descriptors[2], STDERR_FILENO);
+
+    // Setup spawnattr
+    posix_spawnattr_t spawn_attr;
+    posix_spawnattr_init(&spawn_attr);
+    // Masks
+    sigset_t no_signals;
+    sigset_t all_signals;
+    sigemptyset(&no_signals);
+    sigfillset(&all_signals);
+    posix_spawnattr_setsigmask(&spawn_attr, &no_signals);
+    posix_spawnattr_setsigdefault(&spawn_attr, &all_signals);
+    // Flags
+    short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
+    posix_spawnattr_setflags(&spawn_attr, flags);
+
+    // Spawn!
+    return posix_spawn(pid, exec_path, &file_actions, &spawn_attr, args, env);
+}
+#endif
+
+int _subprocess_fork_exec(
+    pid_t *pid,
+    const char *exec_path,
+    const char *working_directory,
+    const int file_descriptors[],
+    char * const args[],
+    char * const env[]
+) {
+    pid_t child_pid = fork();
+
+    // Bind stdin, stdout, and stderr
+    if (file_descriptors[0] != 0) {
+        dup2(file_descriptors[0], STDIN_FILENO);
+    }
+    if (file_descriptors[1] != 0) {
+        dup2(file_descriptors[1], STDOUT_FILENO);
+    }
+    if (file_descriptors[2] != 0) {
+        dup2(file_descriptors[2], STDERR_FILENO);
+    }
+
+    // Finally, exec
+    execve(exec_path, args, env);
+    // If we got here, something went wrong
+    return errno;
+}
+
+#endif

--- a/Sources/_CShims/include/ProcessShims.h
+++ b/Sources/_CShims/include/ProcessShims.h
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#include <unistd.h>
+#include "_CShimsTargetConditionals.h"
+
+#if TARGET_OS_MAC
+#include <spawn.h>
+
+int _subprocess_spawn(
+    pid_t *pid,
+    const char *exec_path,
+    const posix_spawn_file_actions_t *file_actions,
+    const posix_spawnattr_t *spawn_attrs,
+    char * const args[],
+    char * const env[]
+);
+#else // TARGET_OS_MAC
+
+int _subprocess_fork_exec(
+    pid_t *pid,
+    const char *exec_path,
+    const int file_descriptors[],
+    char * const args[],
+    char * const env[]
+);
+
+#endif // TARGET_OS_MAC

--- a/Tests/FoundationEssentialsTests/SubprocessTests.swift
+++ b/Tests/FoundationEssentialsTests/SubprocessTests.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import System
+#if canImport(TestSupport)
+import TestSupport
+#endif
+@testable import FoundationEssentials
+
+final class SubprocessTests : XCTestCase {
+    func testCURL() throws {
+        struct Address: Codable {
+            let ip: String
+        }
+
+        let (readFd, writeFd) = try FileDescriptor.pipe()
+        let curl = Subprocess(
+            executablePath: "/usr/bin/curl",
+            arguments: ["http://ip.jsontest.com/"],
+            environments: [:],
+            standardOutput: writeFd
+        )
+
+        let buffer: UnsafeMutableRawBufferPointer = .allocate(byteCount: 1024, alignment: 1)
+        defer { buffer.deallocate() }
+        let readSize = try readFd.read(into: buffer)
+        let data = Data(bytes: buffer.baseAddress!, count: readSize)
+        let address = try JSONDecoder().decode(Address.self, from: data)
+        XCTAssertTrue(address.ip.contains(":") || address.ip.contains("."))
+    }
+}


### PR DESCRIPTION
This patch introduces an experimental `Subprocess` type. It only has one public method: `public func run() throws -> ProcessIdentifier` and it supports both Linux and macOS.